### PR TITLE
fix app crash when navigating from favourite screen to detail screen

### DIFF
--- a/app/src/main/java/com/example/flicks/overview/FavouritesOverviewFragment.kt
+++ b/app/src/main/java/com/example/flicks/overview/FavouritesOverviewFragment.kt
@@ -1,6 +1,7 @@
 package com.example.flicks.overview
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -36,7 +37,7 @@ class FavouritesOverviewFragment : Fragment() {
         })
         viewModel.navigateToSelectedMovie.observe(this, Observer {
             if (null != it) {
-                this.findNavController().navigate(OverviewFragmentDirections.actionShowDetail(it))
+                this.findNavController().navigate(FavouritesOverviewFragmentDirections.actionFavouritesOverviewFragmentToDetailFragment(it))
                 viewModel.displayPropertyDetailsComplete()
             }
         })

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -30,7 +30,11 @@
     </fragment>
     <fragment android:id="@+id/favouritesOverviewFragment"
               android:name="com.example.flicks.overview.FavouritesOverviewFragment"
-              android:label="FavouritesOverviewFragment"/>
+              android:label="FavouritesOverviewFragment">
+        <action
+                android:id="@+id/action_favouritesOverviewFragment_to_detailFragment"
+                app:destination="@id/detailFragment" />
+    </fragment>
     <fragment android:id="@+id/homeFragment" android:name="com.example.flicks.HomeFragment"
               android:label="HomeFragment"/>
 


### PR DESCRIPTION
This PR fixes issue #14 
#### Checklist:
- [x] edit navigation graph and create a link from favourites screen to detail screen
- [x] edit the favouritesoverviewfragment to provide the direction action
